### PR TITLE
Refresh alpha from master and preserve previous alpha work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
     if: needs.semantic-release.outputs.prev_version != needs.semantic-release.outputs.next_version
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: v${{ needs.semantic-release.outputs.next_version }}
       - run: echo "version=${{ needs.semantic-release.outputs.next_version }}" >> $GITHUB_ENV
 
       - run: |

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,3 +1,8 @@
+branches:
+  - master
+  - name: alpha
+    prerelease: true
+
 plugins:
   - semantic-release-gitmoji
   - "@semantic-release/npm"

--- a/Packages/com.nekometer.esnya.udon-sun-controller/package.json
+++ b/Packages/com.nekometer.esnya.udon-sun-controller/package.json
@@ -35,9 +35,8 @@
       "path": "Demo"
     }
   ],
-  "unity": "2019.4",
+  "unity": "2022.3",
   "vpmDependencies": {
-    "com.vrchat.udonsharp": "1.1.7",
-    "com.vrchat.worlds": "3.1.1"
+    "com.vrchat.worlds": "3.10.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,6 @@
     "foreach-cli": "^1.8.1",
     "semantic-release": "^19.0.5",
     "semantic-release-gitmoji": "^1.6.3"
-  }
+  },
+  "unity": "2022.3"
 }


### PR DESCRIPTION
## Summary
- preserve the previous `alpha` state on `codex/alpha-snapshot-20260409`
- recreate `alpha` from the repository default line (`master`/`main`)
- carry the preserved alpha work forward through a reviewable PR

## Why
This keeps prerelease work reviewable while preserving the previous `alpha` line intact.

## Validation
- branch pointers updated so `alpha` now starts from the primary branch
- previous `alpha` history preserved on `codex/alpha-snapshot-20260409`